### PR TITLE
Adding JVMARGS environment variable

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -55,17 +55,18 @@ All suported tags can be found on [dockerhub](https://hub.docker.com/r/brammys/n
 
 ### Environment variables
 
-| ENV variable    	| Default value           	| Description                                                                            	                                                    |
-|-----------------	|-------------------------	|---------------------------------------------------------------------------------------------------------------------------------------------  |
-| `WORLD`            	| `world` 	                                    | The name of the world that will be used.                                                                              |
-| `SLOTS`            	| `10` 	                                        | The Amount of player slots.                                                                                           |
-| `OWNER`            	| `` 	                                        | Anyone that connects with this name, will get owner permissions.                                                      |
-| `MOTD`            	| `"This server is made possible by Docker!"`   | Sets the message of the day. Use \n for new line.                                                                     |
-| `PASSWORD`            | `` 	                                        | The password for the server, blank for no password.                                                                   |
-| `GIVE_CLIENTS_POWER`  | `0` 	                                        | Whether the server should check clients action. Experience will be much smoother when turned off. (`0` off, `1` on)   |
-| `PAUSE`            	| `0` 	                                        | Pauses the world when there are no players in server. (`0` off, `1` on)                                               |
-| `LOGGING`            	| `1` 	                                        | Generate a log file for each session. (`0` off, `1` on)                                                               |
-| `ZIP`            	    | `1` 	                                        | Wether saves should be compressed. (`0` off, `1` on)                                                                  |
+| ENV variable    	    | Default value           	                    | Description                                                                            	                                             |
+|-------------------	|-------------------------------------------	|------------------------------------------------------------------------------------------------------------------------------------    |
+| `WORLD`            	| `world` 	                                    | The name of the world that will be used.                                                                                               |
+| `SLOTS`            	| `10` 	                                        | The Amount of player slots.                                                                                                            |
+| `OWNER`            	| `` 	                                        | Anyone that connects with this name, will get owner permissions.                                                                       |
+| `MOTD`            	| `"This server is made possible by Docker!"`   | Sets the message of the day. Use \n for new line.                                                                                      |
+| `PASSWORD`            | `` 	                                        | The password for the server, blank for no password.                                                                                    |
+| `GIVE_CLIENTS_POWER`  | `0` 	                                        | Whether the server should check clients action. Experience will be much smoother when turned off. (`0` off, `1` on)                    |
+| `PAUSE`            	| `0` 	                                        | Pauses the world when there are no players in server. (`0` off, `1` on)                                                                |
+| `LOGGING`            	| `1` 	                                        | Generate a log file for each session. (`0` off, `1` on)                                                                                |
+| `ZIP`            	    | `1` 	                                        | Whether saves should be compressed. (`0` off, `1` on)                                                                                  |
+| `JVMARGS`            	| `` 	                                        | Any extra arguments to supply to the JVM via the [java command](https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html).   |
 
 ### Volumes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ ENV PAUSE=0
 ENV GIVE_CLIENTS_POWER=0
 ENV LOGGING=1
 ENV ZIP=1
+ENV JVMARGS=""
 
 # Install java, wget and unzip and cleanup package cache.
 RUN apk --update add wget unzip 
@@ -49,7 +50,7 @@ FROM base AS final
 COPY --from=build /necesse-server-${version}-${build} /necesse/
 
 WORKDIR /necesse
-ENTRYPOINT java \
+ENTRYPOINT java ${JVMARGS} \
 -jar Server.jar \
 -nogui -localdir \
 -world ${WORLD} \


### PR DESCRIPTION
Added a JVMARGS environment variable which can be used to modify general settings of the JVM that the necesse server runs in.

## Description
- Added environment variable to the Dockerfile and appended it directly after the java command
- The environment variable defaults to `""`
- Updated README to reflect changes

## Motivation and Context
The VM I was using to run the server has somewhat limited resources, so I ran into performance issues due to lack of heap space. The JVM defaults to about 1/3 of the physical RAM for maximum heap space. In cases where the machine is used exclusively to run a single java application, this default is unnecessarily restrictive. So, to improve performance, I wanted to append `-Xmx3G` to the java command. Also, instead of providing just a heap space environment variable, I figured allowing any java argument could be useful.

## How has this been tested?
I ran my forked version of the docker image for a few days with `JVMARGS=-Xmx3G`, with a few people playing on the server. The new settings seem to have alleviated the performance issues.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.


## PS:
Great job on this repo by the way, I really appreciate the automated build version updates!